### PR TITLE
Corrected URL for the Teams Learn Challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Still interested in getting more information during your own time? You can visit
 
 ## Participate in the Teams Learn Challenge
 
-Interested in some friendly competition? We will be offering prizes for those that complete the [Teams Learn Challenge](aka.ms/teamslearnchallenge) beginning on December 16, 2020 until January 13, 2021.
+Interested in some friendly competition? We will be offering prizes for those that complete the [Teams Learn Challenge](http://aka.ms/teamslearnchallenge) beginning on December 16, 2020 until January 13, 2021.
 
 While completing the challenge, use these [resources](https://docs.microsoft.com/en-us/microsoftteams/platform/?WT.mc_id=m365-9410-cxa) to help you if you get stuck.
 
@@ -45,6 +45,6 @@ Tweet us at [@LearnTV](https://twitter.com/LearnTV) with the #LearnTogether and 
 
 Start learning more today by visiting [Microsoft Learn's Microsoft Teams Developer Documentation](https://docs.microsoft.com/en-us/microsoftteams/platform/?WT.mc_id=m365-9410-cxa). 
 
-Interested in some friendly competition? We will be offering prizes for those that complete the [Teams Learn Challenge](aka.ms/teamslearnchallenge) beginning on December 16, 2020 until January 15, 2021.
+Interested in some friendly competition? We will be offering prizes for those that complete the [Teams Learn Challenge](http://aka.ms/teamslearnchallenge) beginning on December 16, 2020 until January 15, 2021.
 
 Follow [@LearnTV](https://twitter.com/LearnTV) on Twitter to stay in touch about this event (#LearnTogether) and future events and streams on [Learn TV](http://aka.ms/learntv).


### PR DESCRIPTION
To make the URL absolute, prepended the URL with `http://` 

### How to check for error
- Navigate to `README.md`
- Click on `Teams Learn Challenge`
- It gives an error `404 Page not Found`, as the URL displayed is, `https://github.com/microsoft/learntogether-devappsforteams/blob/main/aka.ms/teamslearnchallenge`

### Reason 
Relative URL has been used in the markdown file

### Solution
- Use the Absolute URL instead of Relative URL
